### PR TITLE
 Add check that localized Global Area versions don't have blocks

### DIFF
--- a/concrete/src/Area/GlobalArea.php
+++ b/concrete/src/Area/GlobalArea.php
@@ -1,15 +1,16 @@
 <?php
+
 namespace Concrete\Core\Area;
 
-use Concrete\Core\Page\Stack\StackList;
+use Concrete\Core\Multilingual\Page\Section\Section as MultilingualSection;
 use Concrete\Core\Page\Collection\Version\VersionList;
+use Concrete\Core\Page\Stack\StackList;
+use Concrete\Core\Site\Service as SiteService;
+use Concrete\Core\Support\Facade\Application;
 use Loader;
 use Page;
 use Permissions;
 use Stack;
-use Concrete\Core\Multilingual\Page\Section\Section as MultilingualSection;
-use Concrete\Core\Support\Facade\Application;
-use Concrete\Core\Site\Service as SiteService;
 
 class GlobalArea extends Area
 {
@@ -42,7 +43,7 @@ class GlobalArea extends Area
     {
         $db = Loader::db();
         Stack::getOrCreateGlobalArea($arHandle);
-        $db->Replace('Areas', array('cID' => $c->getCollectionID(), 'arHandle' => $arHandle, 'arIsGlobal' => 1), array('arHandle', 'cID'), true);
+        $db->Replace('Areas', ['cID' => $c->getCollectionID(), 'arHandle' => $arHandle, 'arIsGlobal' => 1], ['arHandle', 'cID'], true);
         $this->refreshCache($c);
         $area = self::get($c, $arHandle);
         $area->rescanAreaPermissionsChain();
@@ -75,30 +76,6 @@ class GlobalArea extends Area
     }
 
     /**
-     * @param Page $c
-     *
-     * @return Page
-     */
-    protected function getGlobalAreaStackObject($c = false)
-    {
-        if (!$c) {
-            $c = Page::getCurrentPage();
-        }
-        $cp = new Permissions($c);
-        $contentSource = Stack::MULTILINGUAL_CONTENT_SOURCE_CURRENT;
-        if ($this->ignoreCurrentMultilingualLanguageSection) {
-            $contentSource = Stack::MULTILINGUAL_CONTENT_SOURCE_DEFAULT;
-        }
-        if ($cp->canViewPageVersions()) {
-            $stack = Stack::getByName($this->arHandle, 'RECENT', null, $contentSource);
-        } else {
-            $stack = Stack::getByName($this->arHandle, 'ACTIVE', null, $contentSource);
-        }
-
-        return $stack;
-    }
-
-    /**
      * @return int
      */
     public function getTotalBlocksInAreaEditMode()
@@ -107,8 +84,9 @@ class GlobalArea extends Area
         $ax = Area::get($stack, STACKS_AREA_NAME);
 
         $db = Loader::db();
+
         return (int) $db->GetOne('select count(b.bID) from CollectionVersionBlocks cvb inner join Blocks b on cvb.bID = b.bID inner join BlockTypes bt on b.btID = bt.btID where cID = ? and cvID = ? and arHandle = ?',
-            array($stack->getCollectionID(), $stack->getVersionID(), $ax->getAreaHandle())
+            [$stack->getCollectionID(), $stack->getVersionID(), $ax->getAreaHandle()]
         );
     }
 
@@ -127,13 +105,13 @@ class GlobalArea extends Area
         } else {
             $stack = Stack::getByName($this->arHandle, 'ACTIVE', null, $contentSource);
         }
-        $blocksTmp = array();
+        $blocksTmp = [];
         if (is_object($stack)) {
             $blocksTmp = $stack->getBlocks(STACKS_AREA_NAME);
             $globalArea = self::get($stack, STACKS_AREA_NAME);
         }
 
-        $blocks = array();
+        $blocks = [];
         foreach ($blocksTmp as $ab) {
             $ab->setBlockAreaObject($globalArea);
             $ab->setBlockActionCollectionID($stack->getCollectionID());
@@ -159,8 +137,8 @@ class GlobalArea extends Area
     public static function deleteByName($arHandle)
     {
         $db = Loader::db();
-        $db->Execute('select cID from Areas where arHandle = ? and arIsGlobal = 1', array($arHandle));
-        $db->Execute('delete from Areas where arHandle = ? and arIsGlobal = 1', array($arHandle));
+        $db->Execute('select cID from Areas where arHandle = ? and arIsGlobal = 1', [$arHandle]);
+        $db->Execute('delete from Areas where arHandle = ? and arIsGlobal = 1', [$arHandle]);
     }
 
     /**
@@ -205,11 +183,11 @@ class GlobalArea extends Area
                 // get list of all available page versions, we only delete areas if they never had any content
                 $versionList = new VersionList($stackAlternative);
                 $versions = $versionList->get();
-    
+
                 foreach ($versions as $version) {
                     $pageVersion = Page::getByID($version->getCollectionID(), $version->getVersionID());
                     $totalBlocks = count($pageVersion->getBlockIDs());
-    
+
                     if ($totalBlocks > 0) {
                         $hasBlocks = true;
                         break 2;
@@ -223,4 +201,27 @@ class GlobalArea extends Area
         }
     }
 
+    /**
+     * @param Page $c
+     *
+     * @return Page
+     */
+    protected function getGlobalAreaStackObject($c = false)
+    {
+        if (!$c) {
+            $c = Page::getCurrentPage();
+        }
+        $cp = new Permissions($c);
+        $contentSource = Stack::MULTILINGUAL_CONTENT_SOURCE_CURRENT;
+        if ($this->ignoreCurrentMultilingualLanguageSection) {
+            $contentSource = Stack::MULTILINGUAL_CONTENT_SOURCE_DEFAULT;
+        }
+        if ($cp->canViewPageVersions()) {
+            $stack = Stack::getByName($this->arHandle, 'RECENT', null, $contentSource);
+        } else {
+            $stack = Stack::getByName($this->arHandle, 'ACTIVE', null, $contentSource);
+        }
+
+        return $stack;
+    }
 }


### PR DESCRIPTION
Stacks and Global Areas have a neutral version (used for any locale), and they may have a localized version.

Let's check that the localized versions are empty too.